### PR TITLE
Add SQLite storage with GeoIP and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,49 @@
 # 🕵️ Proxy Hunter Dashboard
 
-**Proxy Hunter Dashboard** là hệ thống tự động quét IP theo quốc gia, kiểm tra proxy hoạt động và hiển thị trực quan qua giao diện web (FastAPI).
+**Proxy Hunter Dashboard** là hệ thống tự động quét IP theo quốc gia, kiểm tra proxy hoạt động và hiển thị qua FastAPI.
 
 ## 🚀 Tính năng
 - Tự động tải CIDR từ ipdeny.com
 - Scan cổng phổ biến qua zmap (8080, 3128, 443)
-- Kiểm tra proxy sống bằng HTTP(S)
+- Kiểm tra proxy sống bằng HTTP(S) và lưu vào SQLite
+- Tích hợp tra cứu GeoIP qua ip-api.com
 - Giao diện dashboard trực quan
 - Lập lịch kiểm tra lại proxy định kỳ
 
 ## 🗂 Cấu trúc thư mục
-
 ```
 proxy_hunter/
-├── app/                 # Logic proxy
+├── crawler/             # Logic proxy
 │   ├── checker.py
 │   ├── crawler.py
 │   ├── scheduler.py
-│   └── storage.py
-├── dashboard/           # FastAPI dashboard
+│   ├── storage.py
+│   └── geoip.py
+├── server/              # FastAPI dashboard
 │   └── server.py
-├── data/                # CIDRs, proxy output
+├── data/                # CIDRs, proxy output, database
 ├── config.py            # Cấu hình
 ├── main.py              # Entry point
 └── requirements.txt     # Thư viện
 ```
 
 ## ▶️ Hướng dẫn chạy
-
 ### 1. Cài đặt
-
 ```bash
 pip install -r requirements.txt
 sudo apt install zmap
 ```
 
 ### 2. Khởi chạy
-
 ```bash
 python main.py
 ```
-
-Dashboard truy cập tại: [http://localhost:8000](http://localhost:8000)
+Dashboard truy cập tại: <http://localhost:8000>
 
 ## ⚙️ Tuỳ chỉnh
-
-Thay đổi trong `config.py`:
-
+Trong `config.py`:
 ```python
 PORTS = [8080, 3128, 443]
 THREADS = 50
 TEST_URL = 'https://httpbin.org/ip'
 ```
-
-## 📊 Mở rộng
-- [ ] Lưu Redis/SQLite
-- [ ] Tích hợp thông tin GeoIP
-- [ ] Export CSV, gửi alert Telegram

--- a/config.py
+++ b/config.py
@@ -3,3 +3,6 @@ ZMAP_PATH = 'zmap'
 THREADS = 50
 TEST_URL = 'https://httpbin.org/ip'
 TIMEOUT = 5
+DB_PATH = 'data/proxies.db'
+GEOIP_URL = 'http://ip-api.com/json/'
+

--- a/crawler/checker.py
+++ b/crawler/checker.py
@@ -1,29 +1,43 @@
 import requests
+import time
 from concurrent.futures import ThreadPoolExecutor
 from config import THREADS, TEST_URL, TIMEOUT
-from crawler.storage import add_live_proxy
+from crawler.storage import add_live_proxy, remove_proxy, get_all_proxies
+from crawler.geoip import get_country
 
-def check_proxy(proxy_line):
+
+def check_proxy(proxy_line: str):
     proxy_line = proxy_line.strip()
     if not proxy_line:
         return
+    ip, port = proxy_line.split(":")
     proxies = {
         "http": f"http://{proxy_line}",
-        "https": f"http://{proxy_line}"
+        "https": f"http://{proxy_line}",
     }
     try:
+        start = time.perf_counter()
         r = requests.get(TEST_URL, proxies=proxies, timeout=TIMEOUT)
+        latency_ms = int((time.perf_counter() - start) * 1000)
         if r.status_code == 200:
-            ip, port = proxy_line.split(":")
-            add_live_proxy(ip, int(port))
-            print(f"[LIVE] {proxy_line}")
+            country = get_country(ip)
+            add_live_proxy(ip, int(port), latency_ms, country)
+            print(f"[LIVE] {proxy_line} {latency_ms}ms")
             return
-    except:
+    except Exception:
         pass
+    remove_proxy(ip, int(port))
     print(f"[DIE] {proxy_line}")
 
-def check_proxies(proxy_file):
+
+def check_proxies(proxy_file: str):
     with open(proxy_file, 'r') as f:
         proxies = f.read().splitlines()
+    with ThreadPoolExecutor(max_workers=THREADS) as executor:
+        executor.map(check_proxy, proxies)
+
+
+def recheck_db_proxies():
+    proxies = [f"{p['ip']}:{p['port']}" for p in get_all_proxies()]
     with ThreadPoolExecutor(max_workers=THREADS) as executor:
         executor.map(check_proxy, proxies)

--- a/crawler/geoip.py
+++ b/crawler/geoip.py
@@ -1,0 +1,12 @@
+import requests
+
+def get_country(ip: str) -> str:
+    """Return ISO country code for given IP using ip-api.com."""
+    try:
+        r = requests.get(f"http://ip-api.com/json/{ip}", timeout=5)
+        data = r.json()
+        if data.get("status") == "success":
+            return data.get("countryCode", "N/A")
+    except Exception:
+        pass
+    return "N/A"

--- a/crawler/scheduler.py
+++ b/crawler/scheduler.py
@@ -1,7 +1,9 @@
 from apscheduler.schedulers.background import BackgroundScheduler
-from crawler.checker import check_proxies
+from crawler.checker import check_proxies, recheck_db_proxies
+
 
 def start_scheduler():
     scheduler = BackgroundScheduler()
     scheduler.add_job(lambda: check_proxies("data/proxy_candidates.txt"), 'interval', minutes=10)
+    scheduler.add_job(recheck_db_proxies, 'interval', minutes=5)
     scheduler.start()

--- a/crawler/storage.py
+++ b/crawler/storage.py
@@ -1,18 +1,93 @@
+import os
+import sqlite3
+import threading
 from datetime import datetime
 
-live_proxies = []
+DB_PATH = os.path.join('data', 'proxies.db')
+_conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+_lock = threading.Lock()
 
-def add_live_proxy(ip, port):
-    live_proxies.append({
-        'ip': ip,
-        'port': port,
-        'latency_ms': 500,
-        'last_checked': datetime.utcnow(),
-        'total_checks': 1,
-        'live_checks': 1,
-        'country': 'N/A',
-        'anonymity': 'unknown'
-    })
+
+def init_db():
+    os.makedirs('data', exist_ok=True)
+    with _conn:
+        _conn.execute(
+            '''CREATE TABLE IF NOT EXISTS proxies (
+                ip TEXT,
+                port INTEGER,
+                latency_ms INTEGER,
+                last_checked TEXT,
+                total_checks INTEGER,
+                live_checks INTEGER,
+                country TEXT,
+                PRIMARY KEY (ip, port)
+            )'''
+        )
+
+
+init_db()
+
+
+def add_live_proxy(ip: str, port: int, latency_ms: int, country: str = 'N/A'):
+    now = datetime.utcnow().isoformat()
+    with _lock, _conn:
+        cur = _conn.execute(
+            'SELECT live_checks, total_checks FROM proxies WHERE ip=? AND port=?',
+            (ip, port)
+        )
+        row = cur.fetchone()
+        if row:
+            live_checks, total_checks = row
+            _conn.execute(
+                'UPDATE proxies SET latency_ms=?, last_checked=?, total_checks=?, '
+                'live_checks=?, country=? WHERE ip=? AND port=?',
+                (latency_ms, now, total_checks + 1, live_checks + 1,
+                 country, ip, port)
+            )
+        else:
+            _conn.execute(
+                'INSERT INTO proxies (ip, port, latency_ms, last_checked, '
+                'total_checks, live_checks, country) '
+                'VALUES (?, ?, ?, ?, 1, 1, ?)',
+                (ip, port, latency_ms, now, country)
+            )
+
+
+def remove_proxy(ip: str, port: int):
+    with _lock, _conn:
+        _conn.execute('DELETE FROM proxies WHERE ip=? AND port=?', (ip, port))
+
 
 def get_all_proxies():
-    return live_proxies
+    with _lock, _conn:
+        rows = _conn.execute(
+            'SELECT ip, port, latency_ms, last_checked, total_checks, '
+            'live_checks, country FROM proxies'
+        ).fetchall()
+    result = []
+    for row in rows:
+        result.append({
+            'ip': row[0],
+            'port': row[1],
+            'latency_ms': row[2],
+            'last_checked': datetime.fromisoformat(row[3]),
+            'total_checks': row[4],
+            'live_checks': row[5],
+            'country': row[6],
+        })
+    return result
+
+
+def add_proxy(ip: str, port: int, country: str = 'N/A'):
+    now = datetime.utcnow().isoformat()
+    with _lock, _conn:
+        _conn.execute(
+            'INSERT OR IGNORE INTO proxies '
+            '(ip, port, latency_ms, last_checked, total_checks, live_checks, country) '
+            'VALUES (?, ?, -1, ?, 0, 0, ?)',
+            (ip, port, now, country)
+        )
+
+
+def delete_proxy(ip: str, port: int):
+    remove_proxy(ip, port)

--- a/main.py
+++ b/main.py
@@ -1,16 +1,14 @@
-from app.crawler import scan_all_ports
-from app.checker import check_proxies
-from app.scheduler import start_scheduler
+from crawler.crawler import scan_all_ports
+from crawler.checker import check_proxies
+from crawler.scheduler import start_scheduler
 import threading
 
 if __name__ == '__main__':
     scan_all_ports("vn")  # Có thể đổi country code
     check_proxies("data/proxy_candidates.txt")
 
-    # Chạy dashboard song song
     from server.server import run_dashboard
     threading.Thread(target=run_dashboard, daemon=True).start()
 
-    # Chạy lặp lại proxy checker
     start_scheduler()
     input("\n[ENTER] để dừng chương trình...\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+requests
+apscheduler

--- a/server/server.py
+++ b/server/server.py
@@ -1,12 +1,17 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from datetime import datetime
-from crawler.storage import get_all_proxies
-import os, uvicorn
+from crawler.storage import (
+    get_all_proxies,
+    add_proxy,
+    delete_proxy,
+)
+import uvicorn
 
 app = FastAPI()
 # app.mount("/static", StaticFiles(directory="dashboard/static"), name="static")
+
 
 @app.get("/api/proxies", response_class=JSONResponse)
 def get_proxies():
@@ -20,6 +25,23 @@ def get_proxies():
         })
     return result
 
+
+@app.post("/api/proxies", response_class=JSONResponse)
+async def add_proxy_api(item: dict):
+    ip = item.get("ip")
+    port = item.get("port")
+    if not ip or port is None:
+        raise HTTPException(status_code=400, detail="ip and port required")
+    add_proxy(ip, int(port))
+    return {"status": "ok"}
+
+
+@app.delete("/api/proxies/{ip}/{port}", response_class=JSONResponse)
+def delete_proxy_api(ip: str, port: int):
+    delete_proxy(ip, port)
+    return {"status": "deleted"}
+
+
 @app.get("/", response_class=HTMLResponse)
 def dashboard():
     return HTMLResponse(content="""
@@ -28,8 +50,12 @@ def dashboard():
 <head><meta charset='UTF-8'><title>Proxy Dashboard</title></head>
 <body>
 <h2>Proxy Dashboard</h2>
+<form id="add-form">
+  IP <input id="ip" required> Port <input id="port" type="number" required>
+  <button type="submit">Add</button>
+</form>
 <table border="1" cellpadding="5">
-<thead><tr><th>IP</th><th>Port</th><th>Last Check</th><th>Latency</th><th>Uptime</th><th>Country</th><th>Anonymity</th></tr></thead>
+<thead><tr><th>IP</th><th>Port</th><th>Last Check</th><th>Latency</th><th>Uptime</th><th>Country</th><th></th></tr></thead>
 <tbody id="proxy-table"></tbody>
 </table>
 <script>
@@ -41,18 +67,40 @@ async function loadProxies() {
   for (const p of data) {
     const row = `<tr>
       <td>${p.ip}</td><td>${p.port}</td><td>${p.last_check_human}</td>
-      <td>${p.latency_ms} ms</td><td>${p.uptime}</td><td>${p.country}</td><td>${p.anonymity}</td>
+      <td>${p.latency_ms} ms</td><td>${p.uptime}</td><td>${p.country}</td>
+      <td><button onclick="deleteProxy('${p.ip}', ${p.port})">Del</button></td>
     </tr>`;
     table.innerHTML += row;
   }
 }
+
+async function deleteProxy(ip, port) {
+  await fetch(`/api/proxies/${ip}/${port}`, {method: 'DELETE'});
+  loadProxies();
+}
+
+document.getElementById('add-form').onsubmit = async (e) => {
+  e.preventDefault();
+  const ip = document.getElementById('ip').value;
+  const port = document.getElementById('port').value;
+  await fetch('/api/proxies', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({ip, port})
+  });
+  document.getElementById('ip').value = '';
+  document.getElementById('port').value = '';
+  loadProxies();
+};
+
 loadProxies();
 </script>
 </body>
 </html>
 """)
 
-def humanize_time(dt: datetime):
+
+def humanize_time(dt: datetime) -> str:
     delta = datetime.utcnow() - dt
     seconds = delta.total_seconds()
     if seconds < 60:
@@ -63,6 +111,6 @@ def humanize_time(dt: datetime):
         return f"{int(seconds // 3600)}h ago"
     return f"{int(seconds // 86400)}d ago"
 
+
 def run_dashboard():
-    # os.makedirs("dashboard/static", exist_ok=True)
     uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- store proxies in SQLite and update on recheck
- look up GeoIP info for each live proxy
- remove anonymity column from DB and dashboard
- measure and display real latency
- add API endpoints for managing proxies via dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68520a7f0f34832e9f3f58e7e1794ba9